### PR TITLE
Fix VASI/PAPI always enabled

### DIFF
--- a/NeoFly Tools.ahk
+++ b/NeoFly Tools.ahk
@@ -930,7 +930,7 @@ Goods_HangarLVClick:
 				If (lvQualification != "A") {
 					GuiControl, , Goods_ArrivalHard, 1
 				}
-				If (lvQualifiction != "A" && lvQualifiction != "B") {
+				If (lvQualification != "A" && lvQualification != "B") {
 					GuiControl, , Goods_ArrivalVASI, 1
 				}
 			} else { ; Assume AI is flying


### PR DESCRIPTION
I noticed that VASI/PAPI is always enabled when selecting a plane. Looking into it I found that, in fact, it should only be enabled when selecting turboprop or jet planes; but due this typo the condition does not working.